### PR TITLE
remove limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -409,8 +409,8 @@ function main() {
                       return ret;
                     }
                     default: {
-                      if (s.length > 20) {
-                        seal.replyToSender(ctx, msg, '设定过长，请控制在20字以内');
+                      if (s.length > 65536) {
+                        seal.replyToSender(ctx, msg, '设定过长，请控制在65536字以内');
                         return ret;
                       }
                       ai2.memory.persona = s;
@@ -477,8 +477,8 @@ function main() {
                       return ret;
                     }
                     default: {
-                      if (s.length > 30) {
-                        seal.replyToSender(ctx, msg, '设定过长，请控制在30字以内');
+                      if (s.length > 65536) {
+                        seal.replyToSender(ctx, msg, '设定过长，请控制在65536字以内');
                         return ret;
                       }
                       ai.memory.persona = s;

--- a/src/utils/utils_string.ts
+++ b/src/utils/utils_string.ts
@@ -6,6 +6,16 @@ import { ConfigManager } from "../config/config";
 import { transformMsgIdBack } from "./utils";
 import { AI } from "../AI/AI";
 
+function removeThinkingChains(text: string): string {
+    // 移除 <Think>...</Think> 标签（大小写不敏感，支持多行）
+    text = text.replace(/<think[\s\S]*?<\/think>/gi, '');
+    
+    // 移除 <!-- ... --> 注释（支持多行）
+    text = text.replace(/<!--[\s\S]*?-->/g, '');
+    
+    return text;
+}
+
 export function transformTextToArray(s: string): { type: string, data: { [key: string]: string } }[] {
     const segments = s.split(/(\[CQ:.*?\])/).filter(segment => segment);
     const messageArray: { type: string, data: { [key: string]: string } }[] = [];
@@ -78,6 +88,9 @@ export function transformArrayToText(messageArray: { type: string, data: { [key:
 }
 
 export async function handleReply(ctx: seal.MsgContext, msg: seal.Message, ai: AI, s: string): Promise<{ contextArray: string[], replyArray: string[], images: Image[] }> {
+    // 移除思维链内容
+    s = removeThinkingChains(s);
+    
     const { replymsg, isTrim } = ConfigManager.reply;
 
     // 分离AI臆想出来的多轮对话


### PR DESCRIPTION
This pull request increases the allowed length for persona settings and introduces a utility to clean up AI-generated text by removing certain tags and comments. The main themes are user input validation and AI output sanitization.

**User Input Validation:**
* Increased the maximum allowed length for persona settings from 20/30 characters to 65536 characters in the `main` function of `src/index.ts` to allow for much longer persona descriptions. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L412-R413) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L480-R481)

**AI Output Sanitization:**
* Added a new `removeThinkingChains` function in `src/utils/utils_string.ts` to strip out `<Think>...</Think>` tags (case-insensitive, multiline) and HTML-style comments (`<!-- ... -->`) from AI output.
* Integrated the `removeThinkingChains` function into the `handleReply` function so that all replies have these tags and comments removed before further processing.